### PR TITLE
Fix typo in debian/changelog.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-iptables (1.4.10+vyos2+lithium1) unstable; urgency=low
+iptables (1.4.20+vyos2+lithium1) unstable; urgency=low
 
   * New branch
 


### PR DESCRIPTION
Fix typo in iptables debian/changelog for lithium.
